### PR TITLE
Update veracode-build-dot-net.yml

### DIFF
--- a/.github/workflows/veracode-build-dot-net.yml
+++ b/.github/workflows/veracode-build-dot-net.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build
       run: |
         dotnet restore
-        dotnet publish -c Debug -o ./output
+        dotnet publish -p:UseAppHost=False -p:MapFileExtensions=False -c Debug -o ./output
     - name: Create zip archive
       run: zip -r veracode.zip ./output
 


### PR DESCRIPTION
Add -p:UseAppHost=False to prevent creation of apphost executable. Add -p:MapFileExtensions=False to prevent ClickOnce applications from adding ".deploy"